### PR TITLE
Find modules using specified path

### DIFF
--- a/ormeasy/__init__.py
+++ b/ormeasy/__init__.py
@@ -2,5 +2,5 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-__version_info__ = 0, 1, 2
+__version_info__ = 0, 1, 3
 __version__ = '.'.join(str(v) for v in __version_info__)

--- a/ormeasy/common.py
+++ b/ormeasy/common.py
@@ -10,10 +10,13 @@ import typing
 __all__ = 'get_all_modules', 'import_all_modules',
 
 
-def get_all_modules(module_name: str) -> typing.AbstractSet[str]:
+def get_all_modules(
+    module_name: str, path: typing.Optional[typing.Sequence[str]]=None,
+) -> typing.AbstractSet[str]:
     """Find all module names from given ``module_name``.
 
     :param str module_name: The name of root module which want to find.
+    :param list[str] or None path: The path to find the root module.
     :return: The set of module names.
 
     .. code-block:: python
@@ -25,8 +28,14 @@ def get_all_modules(module_name: str) -> typing.AbstractSet[str]:
 
     """
     root_mod, *_ = module_name.split('.')
-    module_spec = importlib.machinery.PathFinder.find_spec(root_mod)
+    module_spec = importlib.machinery.PathFinder.find_spec(root_mod, path)
     if not module_spec:
+        if path:
+            raise ValueError(
+                '{!s} inexists or is not a python module in {!s}'.format(
+                    root_mod, path
+                )
+            )
         raise ValueError(
             '{!s} inexists or is not a python module'.format(root_mod)
         )
@@ -50,7 +59,9 @@ def get_all_modules(module_name: str) -> typing.AbstractSet[str]:
     return {m for m in module_names if m.startswith(module_name)}
 
 
-def import_all_modules(module_name: str) -> typing.AbstractSet[str]:
+def import_all_modules(
+    module_name: str, path: typing.Optional[typing.Sequence[str]]=None,
+) -> typing.AbstractSet[str]:
     """Import all modules. Maybe it is useful when populate revision script
     in alembic with ``--autogenerate`` option. Since alembic can only detect a
     change/creation of an object that imported in runtime, importing all
@@ -62,9 +73,10 @@ def import_all_modules(module_name: str) -> typing.AbstractSet[str]:
        >>> import_all_modules('ormeasy')
 
     :param str module_name: The module name want to import.
+    :param list[str] or None path: The path to find the root module.
 
     """
-    modules = get_all_modules(module_name)
+    modules = get_all_modules(module_name, path)
     for module_name in modules:
         importlib.import_module(module_name)
     return modules

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+""":mod:`tests` --- Test fixtures and cases of ormeasy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -11,8 +11,11 @@ def test_get_all_modules():
         'urllib.response',
         'urllib.request',
     }
+    assert 'tests.common_test' in get_all_modules('tests')
+    assert get_all_modules('common_test', ['tests']) == {'common_test'}
     with raises(ValueError):
         assert get_all_modules('asdf')
+        assert get_all_modules('tests', ['tests'])
 
 
 def test_get_all_sub_modules():

--- a/tests/sqlalchemy_test.py
+++ b/tests/sqlalchemy_test.py
@@ -12,4 +12,5 @@ class Music:
 
 def test_repr_entity():
     repr_ = repr_entity(Music())
-    assert repr_ == "<sqlalchemy_test.Music name='The box' track_number=6>"
+    expected = "<tests.sqlalchemy_test.Music name='The box' track_number=6>"
+    assert repr_ == expected


### PR DESCRIPTION
If I call `get_all_modules` on `app/orm.py`, currently `get_all_modules` not able to import `app` module.
This PR fixes this problem.