### PR TITLE
Add asyncio support for SQLAlchemy

### DIFF
--- a/docs/ormeasy/asyncsqlalchemy.rst
+++ b/docs/ormeasy/asyncsqlalchemy.rst
@@ -1,0 +1,3 @@
+
+.. automodule:: ormeasy.asyncsqlalchemy
+   :members:

--- a/ormeasy/asyncsqlalchemy.py
+++ b/ormeasy/asyncsqlalchemy.py
@@ -1,0 +1,62 @@
+import contextlib
+import sys
+
+try:
+    from sqlalchemy.ext.asyncio import create_async_engine
+except ImportError:
+    create_async_engine = None
+
+
+if sys.version_info < (3, 7):
+    raise RuntimeError('Python >= 3.7 required.')
+
+
+__all__ = 'test_connection',
+
+
+@contextlib.asynccontextmanager
+async def test_connection(
+    ctx: object,
+    metadata: MetaData,
+    engine: 'sqlalchemy.ext.asyncio.AsyncEngine',
+    real_transaction: bool = False,
+    ctx_connection_attribute_name: str = '_test_fx_connection',
+):
+    """asyncio version of :func:`.sqlalchemy.test_connection`.
+    Since SQLAlchemy 1.4 supports asyncio, it needs to handle async engine
+    as well.
+
+    :param object ctx: Context object to inject test connection into attribute
+    :param MetaData metadata: SQLAlchemy schema metadata
+    :param bool real_transaction: (Optional) Whether to use engine as connection directly
+                                  or make separate connection. Default: `False`
+    :param str ctx_connection_attribute_name: (Optional) Attribute name for injecting
+                                              test connection to the context object
+                                              Default: `'_test_fx_connection'`
+
+    .. code-block::
+
+       async fx_connection(request, fx_engine: AsyncEngine):
+           real_tx = request.config.getoption('--real-tx')
+           async with async_test_connection(request, Base.metadata, fx_engine, real_tx) as connection:
+               yield connection
+
+    """  # noqa
+    if create_async_engine is None:
+        raise RuntimeError('SQLAlchemy >= 1.4 required.')
+    if real_transaction:
+        async with engine.begin() as connection:
+            await connection.run_sync(metadata.create_all)
+    async with engine.connect() as connection:
+        setattr(ctx, ctx_connection_attribute_name, connection)
+        if real_transaction:
+            yield connection
+        else:
+            async with connection.begin() as transaction:
+                await connection.run_sync(Base.metadata.create_all)
+                yield connection
+                await transaction.rollback()
+    if real_transaction:
+        async with engine.begin() as connection:
+            await connection.run_sync(metadata.drop_all)
+    await engine.dispose()

--- a/ormeasy/asyncsqlalchemy.py
+++ b/ormeasy/asyncsqlalchemy.py
@@ -36,6 +36,9 @@ async def test_connection(
 
     .. code-block::
 
+       from pytest import fixture
+
+       @fixture
        async fx_connection(request, fx_engine: AsyncEngine):
            real_tx = request.config.getoption('--real-tx')
            async with async_test_connection(request, Base.metadata, fx_engine, real_tx) as connection:

--- a/ormeasy/asyncsqlalchemy.py
+++ b/ormeasy/asyncsqlalchemy.py
@@ -39,7 +39,7 @@ async def test_connection(
        from pytest import fixture
 
        @fixture
-       async fx_connection(request, fx_engine: AsyncEngine):
+       async def fx_connection(request, fx_engine: AsyncEngine):
            real_tx = request.config.getoption('--real-tx')
            async with async_test_connection(request, Base.metadata, fx_engine, real_tx) as connection:
                yield connection


### PR DESCRIPTION
- SQLAlchemy 1.4 now supports asyncio module. It changes its internal api to deal with connection.
- So `ormeasy` needs to handle async version connection.
- Since [asynccontextmanager][] introduced in Python 3.7, It raise `RuntimeError` if Python version is lower than 3.7.
 
[asynccontextmanager]: https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager