### PR TITLE
Fix bug on asyncsqlalchemy.test_connection

### DIFF
--- a/ormeasy/asyncsqlalchemy.py
+++ b/ormeasy/asyncsqlalchemy.py
@@ -1,6 +1,7 @@
 import contextlib
 import sys
 
+from sqlalchemy.schema import MetaData
 try:
     from sqlalchemy.ext.asyncio import create_async_engine
 except ImportError:
@@ -56,7 +57,7 @@ async def test_connection(
             yield connection
         else:
             async with connection.begin() as transaction:
-                await connection.run_sync(Base.metadata.create_all)
+                await connection.run_sync(metadata.create_all)
                 yield connection
                 await transaction.rollback()
     if real_transaction:


### PR DESCRIPTION
- `MetaData` weren't imported.
- There are no `Base`, since it takes `metadata` as argument.

It was added on https://github.com/spoqa/ormeasy/pull/3. I made a mistake when i am moving `test_connection` function my code base to `ormeasy`. So I forgot importing the module & mis-used inexist variable.

Sorry for my mistake. I've tested on my code base. But for the future it is required to write unittest as well (it is also my mistake not to add unittest at the first place 😭.. )